### PR TITLE
Improve layout of login page

### DIFF
--- a/monash_openid_login/static/monash/css/default.css
+++ b/monash_openid_login/static/monash/css/default.css
@@ -5,8 +5,10 @@
     margin-left: auto;
     max-width: 50%;
 }
+
 .login-box {
     background-color: #e2e2e2;
+    margin-top: 20px;
     padding: 20px 10px;
 
 }
@@ -14,17 +16,19 @@
     padding: 20px 10px;
 }
 
-.col-wrap{
-    overflow: hidden;
-}
-.col{
-    margin-bottom: -99999px;
-    padding-bottom: 99999px;
-}
-
 .login-text {
     text-align: center;
     font-weight: bold;
 }
 
+/* Portrait tablet to landscape and desktop */
+@media (min-width: 768px) {
+    .monash-flexbox {
+        display: flex;
+    }
+}
 
+.monash-logo-login-form {
+    width: 70%;
+    max-width: 200px;
+}

--- a/monash_openid_login/templates/login.html
+++ b/monash_openid_login/templates/login.html
@@ -7,12 +7,16 @@
     </head>
     <legend style="text-align: center"> Log In to Store.Monash</legend>
     <div class="container-fluid">
-        <div class="row-fluid col-wrap">
-            <div class="span6 login-box col">
-            <img src="{% static 'monash/images/monash-uni-logo.png' %}" class="center-image">
+        <div class="row-fluid monash-flexbox">
+          <div class="span6 login-box">
             <form action="" method="post" class="form-horizontal" style="padding-top: 20px ; ">
                 {% csrf_token %}
                 <input name="next_page" type="hidden" value="{{ next_page }}" />
+                <div class="control-group">
+                  <div class="controls">
+                    <img src="{% static 'monash/images/monash-uni-logo.png' %}" class="monash-logo-login-form">
+                  </div>
+                </div>
                 {{ loginForm|bootstrap }}
                 <div class="control-group">
                   <div class="controls">
@@ -24,7 +28,7 @@
             </form>
             </div>
 
-            <div class="span6 login-box col">
+            <div class="span6 login-box">
                 <img src="{% static 'monash/images/aaf-logo.png' %}" style="max-width: 50%" class="center-image">
                 <p class="login-text">Log In using your University ID</p>
                 <a href="{% url 'social:begin' 'aaf' %}?next={% url 'tardis.apps.monash.views.check_account_migration' %}" >

--- a/monash_openid_login/views.py
+++ b/monash_openid_login/views.py
@@ -23,9 +23,9 @@ class LoginView(TemplateView):
         c = super(LoginView, self).get_context_data(**kwargs)
         login_form = LoginForm()
         login_form.fields['username'].widget.attrs['style'] = \
-            "width: 60%; max-width: 200px;"
+            "width: 70%; max-width: 200px;"
         login_form.fields['password'].widget.attrs['style'] = \
-            "width: 60%; max-width: 200px;"
+            "width: 70%; max-width: 200px;"
         c['loginForm'] = login_form
         c['next_page'] = next_page
         return c


### PR DESCRIPTION
- Add a margin at the top of each login box to improve mobile view.
- Remove col and col-wrap CSS classes
- Use flexbox when display width is 768px or more
- Put the Monash logo in the Bootstrap form (to align with username and password fields) and ensure that it doesn't grow too large (max-width 200px)
- Make the username/password fields slightly wider (70%), matching the Monash logo (70%).